### PR TITLE
New latest spec with openebs instead of longhorn

### DIFF
--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -822,12 +822,16 @@ export class Installer {
     i.spec.kubernetes = { version: "1.24.x" };
     i.spec.containerd = { version: this.toDotXVersion(installerVersions.containerd[0]) };
     i.spec.weave = { version: this.toDotXVersion(installerVersions.weave[0]) };
-    i.spec.longhorn = { version: this.toDotXVersion(installerVersions.longhorn[0]) };
-    i.spec.minio = { version: installerVersions.minio[0] };
     i.spec.ekco = { version: "latest" };
     i.spec.contour = { version: this.toDotXVersion(installerVersions.contour[0]) };
     i.spec.registry = { version: this.toDotXVersion(installerVersions.registry[0]) };
     i.spec.prometheus = { version: this.toDotXVersion(installerVersions.prometheus[0]) };
+    i.spec.minio = { version: installerVersions.minio[0] };
+    i.spec.openebs = {
+      version: this.toDotXVersion(installerVersions.openebs[0]),
+      isLocalPVEnabled: true,
+      localPVStorageClassName: "default",
+    };
 
     return i;
   }


### PR DESCRIPTION
Changes "latest" spec from:

```
apiVersion: "cluster.kurl.sh/v1beta1"
kind: "Installer"
metadata: 
  name: "latest"
spec: 
  kubernetes: 
    version: "1.24.x"
  weave: 
    version: "2.6.x"
  contour: 
    version: "1.22.x"
  prometheus: 
    version: "0.58.x"
  registry: 
    version: "2.8.x"
  containerd: 
    version: "1.6.x"
  ekco: 
    version: "latest"
  minio: 
    version: "2022-09-07T22-25-02Z"
  longhorn: 
    version: "1.3.x"
```

to:

```
apiVersion: "cluster.kurl.sh/v1beta1"
kind: "Installer"
metadata: 
  name: "latest"
spec: 
  kubernetes: 
    version: "1.24.x"
  weave: 
    version: "2.6.x"
  contour: 
    version: "1.22.x"
  prometheus: 
    version: "0.58.x"
  registry: 
    version: "2.8.x"
  containerd: 
    version: "1.6.x"
  ekco: 
    version: "latest"
  minio: 
    version: "2022-09-07T22-25-02Z"
  openebs: 
    version: "3.3.x"
    isLocalPVEnabled: true
    localPVStorageClassName: "default"
```