### PR TITLE
Add external addon support to kurl.sh

### DIFF
--- a/src/installers/installer-versions.ts
+++ b/src/installers/installer-versions.ts
@@ -9,29 +9,40 @@ export interface IInstallerVersions {
   [addon: string]: string[];
 }
 
+export interface IExternalInstallerVersions {
+  [addon: string]: IExternalInstallerVersion[];
+}
+
+export interface IExternalInstallerVersion {
+  version: string;
+  kurlVersionCompatibilityRange?: string;
+}
+
 const installerVersionsCache: { [url: string]: IInstallerVersions } = {};
-let externalAddons = {};
+let externalAddons: IExternalInstallerVersions = {};
 let externalAddonTimer: NodeJS.Timer;
 
-function mergeAddonVersions(internalAddonVersions: IInstallerVersions, kurlVersion: string) {
+export function mergeAddonVersions(internalAddonVersions: IInstallerVersions, externalAddons: IExternalInstallerVersions, kurlVersion: string) {
   const addons: IInstallerVersions = {};
   Object.keys(externalAddons).forEach(externalAddonName => {
-    const fileName = externalAddonName.slice(0, externalAddonName.length - 7); // trim off .tar.gz
-    const [name, version] = fileName.split("-");
-    if (!kurlVersion || semver.gte(version, kurlVersion, true)) {
-      if(!addons[name]) {
-        addons[name] = [version]
-      } else {
-        addons[name].unshift(version);
+    externalAddons[externalAddonName].forEach(externalAddon => {
+      let satisfies = false;
+      if (externalAddon.kurlVersionCompatibilityRange) {
+        satisfies = semver.satisfies(kurlVersion, externalAddon.kurlVersionCompatibilityRange, {includePrerelease: true, loose: true});
       }
-    }
+      if (satisfies) {
+        if(!(externalAddonName in addons)) {
+          addons[externalAddonName] = [];
+        }
+        addons[externalAddonName].push(externalAddon.version);
+      }
+    });
   });
   Object.keys(internalAddonVersions).forEach(internalAddonName => {
-    if (!addons[internalAddonName]) {
-      addons[internalAddonName] = internalAddonVersions[internalAddonName];
-    } else {
-      addons[internalAddonName].push(...internalAddonVersions[internalAddonName]);
+    if(!(internalAddonName in addons)) {
+      addons[internalAddonName] = [];
     }
+    addons[internalAddonName].push(...internalAddonVersions[internalAddonName]);
   });
   return addons;
 }
@@ -79,5 +90,5 @@ export async function startExternalAddonPolling() {
 
 export async function getInstallerVersions(distUrl: string, kurlVersion: string): Promise<IInstallerVersions> {
   const internalAddonVersions = await getInternalAddonVersions(distUrl, kurlVersion);
-  return mergeAddonVersions(internalAddonVersions, kurlVersion);
+  return mergeAddonVersions(internalAddonVersions, externalAddons, kurlVersion);
 }

--- a/src/installers/installer-versions.ts
+++ b/src/installers/installer-versions.ts
@@ -90,5 +90,6 @@ export async function startExternalAddonPolling() {
 
 export async function getInstallerVersions(distUrl: string, kurlVersion: string): Promise<IInstallerVersions> {
   const internalAddonVersions = await getInternalAddonVersions(distUrl, kurlVersion);
-  return mergeAddonVersions(internalAddonVersions, externalAddons, kurlVersion);
+  return internalAddonVersions;
+  // return mergeAddonVersions(internalAddonVersions, externalAddons, kurlVersion);
 }

--- a/src/test/installers/installer-versions-test.ts
+++ b/src/test/installers/installer-versions-test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from "mocha";
+import { expect } from "chai";
+import { mergeAddonVersions, IInstallerVersions, IExternalInstallerVersions } from "../../installers/installer-versions";
+
+describe("mergeAddonVersions", () => {
+  it("successfully merges external version ranges", async () => {
+    const internalAddonVersions: IInstallerVersions = {
+      kotsadm: ["1.83.1", "1.83.0", "alpha", "nightly"],
+      another: ["1.1.0", "1.0.0"],
+    };
+    const externalAddonVersions: IExternalInstallerVersions = {
+      kotsadm: [
+        { version: "1.87.0", kurlVersionCompatibilityRange: ">= v2022.09.20-0" },
+        { version: "1.86.0", kurlVersionCompatibilityRange: ">= v2022.09.19-2" },
+        { version: "1.85.0", kurlVersionCompatibilityRange: ">= v2022.09.19-1" },
+        { version: "1.84.0", kurlVersionCompatibilityRange: ">= v2022.09.19-0" },
+      ]
+    }
+    expect(mergeAddonVersions(internalAddonVersions, externalAddonVersions, "v2022.09.18-0")["another"]).to.deep.equal(["1.1.0", "1.0.0"]);
+    expect(mergeAddonVersions(internalAddonVersions, externalAddonVersions, "v2022.09.18-0")["kotsadm"]).to.deep.equal(["1.83.1", "1.83.0", "alpha", "nightly"]);
+    expect(mergeAddonVersions(internalAddonVersions, externalAddonVersions, "v2022.09.19-0")["kotsadm"]).to.deep.equal(["1.84.0", "1.83.1", "1.83.0", "alpha", "nightly"]);
+    expect(mergeAddonVersions(internalAddonVersions, externalAddonVersions, "v2022.09.19-1")["kotsadm"]).to.deep.equal(["1.85.0", "1.84.0", "1.83.1", "1.83.0", "alpha", "nightly"]);
+    expect(mergeAddonVersions(internalAddonVersions, externalAddonVersions, "v2022.09.21-0")["kotsadm"]).to.deep.equal(["1.87.0", "1.86.0", "1.85.0", "1.84.0", "1.83.1", "1.83.0", "alpha", "nightly"]);
+  });
+});


### PR DESCRIPTION
Add explicit version rather than inferring it from file name.
Use semver range.
Disable support for now until we test workflows in dependent projects.