### PR TITLE
Use s3Override url for external add-ons

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -343,11 +342,7 @@ func downloadImage(ctx context.Context, image string, destPath string) error {
 func pipeAddonArchive(dst *tar.Writer, srcURL string) error {
 	resp, err := http.Get(srcURL)
 	if err != nil {
-		filename := path.Base(srcURL)
-		resp, err = http.Get(fmt.Sprintf("https://kurl-sh.s3.amazonaws.com/external/%s", filename))
-		if err != nil {
-			return err
-		}
+		return err
 	}
 	defer resp.Body.Close()
 

--- a/kustomize/overlays/production/deployment.yaml
+++ b/kustomize/overlays/production/deployment.yaml
@@ -45,9 +45,11 @@ spec:
           value: "1"
         - name: KURL_URL
           value: https://kurl.sh
-        - name: DIST_URL # comment out to use s3 directly instead of through cloudflare
-          value: https://s3.kurl.sh/dist
+        - name: BUCKET_URL # comment out to use s3 directly instead of through cloudflare
+          value: https://s3.kurl.sh
         - name: KURL_BUCKET
           value: kurl-sh
         - name: NODE_ENV
           value: production
+        - name: EXCLUDE_EXTERNAL_ADDONS # disable external add-on support on production for now
+          value: "1"

--- a/kustomize/overlays/staging/deployment.yaml
+++ b/kustomize/overlays/staging/deployment.yaml
@@ -45,8 +45,8 @@ spec:
           value: "1"
         - name: KURL_URL
           value: https://staging.kurl.sh
-        - name: DIST_URL # comment out to use s3 directly instead of through cloudflare
-          value: https://s3-staging.kurl.sh/staging
+        - name: BUCKET_URL # comment out to use s3 directly instead of through cloudflare
+          value: https://s3-staging.kurl.sh
         - name: KURL_BUCKET
           value: kurl-sh
         - name: NODE_ENV

--- a/src/client/index_test.ts
+++ b/src/client/index_test.ts
@@ -502,7 +502,7 @@ describe("PUT /installer/<id>", () => {
 
 describe("GET /<installerID>", () => {
   describe("/latest", async () => {
-    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions);
+    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions, {});
 
     it(`injects k8s ${latestResolve.spec.kubernetes?.version}, weave ${latestResolve.spec.weave?.version}, rook ${latestResolve.spec.rook?.version}, contour ${latestResolve.spec.contour?.version}, registry ${latestResolve.spec.registry?.version}, prometheus ${latestResolve.spec.prometheus?.version}, docker ${latestResolve.spec.docker?.version}`, async () => {
       const script = await client.getInstallScript("latest");
@@ -560,7 +560,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(velero);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions)).spec.velero?.version}`));
+      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.velero?.version}`));
     });
   });
 
@@ -576,7 +576,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(minio);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions)).spec.minio?.version}`));
+      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.minio?.version}`));
     });
   });
 
@@ -592,7 +592,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(openebs);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions)).spec.openebs?.version}`));
+      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.openebs?.version}`));
     });
   });
 
@@ -608,7 +608,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(ekco);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions)).spec.ekco?.version}`));
+      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.ekco?.version}`));
     });
   });
 
@@ -624,7 +624,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(rookBlock);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions)).spec.rook?.version}`));
+      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.rook?.version}`));
     });
   });
 
@@ -663,7 +663,7 @@ describe("GET /<installerID>", () => {
 
 describe("GET /<installerID>/join.sh", () => {
   describe("/latest/join.sh", async () => {
-    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions);
+    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions, {});
 
     it(`injects k8s ${latestResolve.spec.kubernetes?.version}, weave ${latestResolve.spec.weave?.version}, rook ${latestResolve.spec.rook?.version}, contour ${latestResolve.spec.contour?.version}, registry ${latestResolve.spec.registry?.version}, prometheus ${latestResolve.spec.prometheus?.version}`, async () => {
       const script = await client.getJoinScript("latest");

--- a/src/controllers/Bundles.ts
+++ b/src/controllers/Bundles.ts
@@ -13,7 +13,7 @@ import { logger } from "../logger";
 import { MetricsStore } from "../util/services/metrics";
 import * as requestIP from "request-ip";
 import { getDistUrl, getPackageUrlPrefix, kurlVersionOrDefault } from "../util/package";
-import { getInstallerVersions } from "../installers/installer-versions";
+import { getExternalAddonVersions, getInstallerVersions } from "../installers/installer-versions";
 
 interface ErrorResponse {
   error: any;
@@ -75,7 +75,8 @@ export class Bundle {
       return notFoundResponse;
     }
 
-    installer = await installer.resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    installer = await installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -12,7 +12,7 @@ import {
 import { instrumented } from "monkit";
 import { Installer, InstallerObject, InstallerStore } from "../installers";
 import decode from "../util/jwt";
-import { getInstallerVersions } from "../installers/installer-versions";
+import { getExternalAddonVersions, getInstallerVersions } from "../installers/installer-versions";
 import { getDistUrl, kurlVersionOrDefault } from "../util/package";
 
 interface ErrorResponse {
@@ -95,7 +95,8 @@ export class Installers {
     }
     i.id = i.hash();
 
-    const err = await (await i.resolve(installerVersions)).validate(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
     if (err) {
       response.status(400);
       return err;
@@ -192,7 +193,8 @@ export class Installers {
       return notFoundResponse;
     }
     if (resolve) {
-      installer = await installer.resolve(installerVersions);
+      const externalVersions = getExternalAddonVersions();
+      installer = await installer.resolve(installerVersions, externalVersions);
     }
     if (installer.id === "latest") {
       installer.id = "";
@@ -235,7 +237,8 @@ export class Installers {
 
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
-    const err = await (await i.resolve(installerVersions)).validate(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
     if (err) {
       response.status(400);
       return err;
@@ -293,8 +296,9 @@ export class Installers {
       const kurlVersion = kurlVersionOrDefault();
 
       const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
-  
-      const err = await (await i.resolve(installerVersions)).validate(installerVersions);
+
+      const externalVersions = getExternalAddonVersions();
+      const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
       if (err) {
         response.status(400);
         return err;

--- a/src/controllers/Scripts.ts
+++ b/src/controllers/Scripts.ts
@@ -11,7 +11,7 @@ import { Templates } from "../util/services/templates";
 import { MetricsStore } from "../util/services/metrics";
 import { logger } from "../logger";
 import * as requestIP from "request-ip";
-import { getInstallerVersions } from "../installers/installer-versions";
+import { getExternalAddonVersions, getInstallerVersions } from "../installers/installer-versions";
 import { getDistUrl, kurlVersionOrDefault } from "../util/package";
 
 interface ErrorResponse {
@@ -60,7 +60,8 @@ export class Installers {
       return notFoundResponse;
     }
 
-    installer = await installer.resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    installer = await installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
@@ -93,11 +94,12 @@ export class Installers {
       return notFoundResponse;
     }
 
-    installer = await installer.resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    installer = await installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
-    installer = await installer.resolve(installerVersions);
+    installer = await installer.resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -122,7 +124,8 @@ export class Installers {
       return notFoundResponse;
     }
 
-    installer = await installer.resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    installer = await installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
@@ -141,7 +144,8 @@ export class Installers {
     const kurlVersion = kurlVersionOrDefault(kvarg);
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
-    const installer = await (Installer.latest(installerVersions)).resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    const installer = await (Installer.latest(installerVersions)).resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -176,7 +180,8 @@ export class Installers {
       return notFoundResponse;
     }
 
-    installer = await installer.resolve(installerVersions);
+    const externalVersions = getExternalAddonVersions();
+    installer = await installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 

--- a/src/installers/installer-versions.ts
+++ b/src/installers/installer-versions.ts
@@ -16,6 +16,7 @@ export interface IExternalInstallerVersions {
 export interface IExternalInstallerVersion {
   version: string;
   kurlVersionCompatibilityRange?: string;
+  sha256Sum?: string;
 }
 
 const installerVersionsCache: { [url: string]: IInstallerVersions } = {};
@@ -90,6 +91,12 @@ export async function startExternalAddonPolling() {
 
 export async function getInstallerVersions(distUrl: string, kurlVersion: string): Promise<IInstallerVersions> {
   const internalAddonVersions = await getInternalAddonVersions(distUrl, kurlVersion);
-  return internalAddonVersions;
-  // return mergeAddonVersions(internalAddonVersions, externalAddons, kurlVersion);
+  if (process.env.EXCLUDE_EXTERNAL_ADDONS) {
+    return internalAddonVersions;
+  }
+  return mergeAddonVersions(internalAddonVersions, externalAddons, kurlVersion);
+}
+
+export function getExternalAddonVersions(): IExternalInstallerVersions {
+  return externalAddons;
 }

--- a/src/util/package/index.ts
+++ b/src/util/package/index.ts
@@ -13,13 +13,24 @@ export function getDistUrl(): string {
   if (process.env["DIST_URL"]) {
     return process.env["DIST_URL"] as string;
   }
-  let distUrl = `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
+  let distUrl = getBucketUrl();
   if (process.env["NODE_ENV"] === "production") {
     distUrl += "/dist";
   } else {
     distUrl += "/staging";
   }
   return distUrl;
+}
+
+export function getExternalUrl(): string {
+  return `${getBucketUrl()}/external`;
+}
+
+export function getBucketUrl(): string {
+  if (process.env["BUCKET_URL"]) {
+    return process.env["BUCKET_URL"] as string;
+  }
+  return `https://${process.env["KURL_BUCKET"]}.s3.amazonaws.com`;
 }
 
 export function kurlVersionOrDefault(kurlVersion?: string, i?: Installer): string {


### PR DESCRIPTION
Allows kURL to explicitly fetch external add-ons from s3Override rather than falling back on 404s