### PR TITLE
feat: external add-ons support for past releases

### DIFF
--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -117,10 +117,7 @@ export class Installers {
   ): Promise<any> {
     response.type("application/json");
 
-    let kurlVersion = version;
-    if (!version) {
-        kurlVersion = kurlVersionOrDefault();
-    }
+    const kurlVersion = (version != undefined) ? version : kurlVersionOrDefault();
 
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -117,7 +117,7 @@ export class Installers {
   ): Promise<any> {
     response.type("application/json");
 
-    const kurlVersion = (version != undefined) ? version : kurlVersionOrDefault();
+    const kurlVersion = version ? version : kurlVersionOrDefault();
 
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -113,7 +113,7 @@ export class Installers {
   @Get("/version/:version")
   public async getInstallerVersions(
     @Res() response: Express.Response,
-    @PathParams("version") version: string,
+    @PathParams("version") version: string|undefined,
   ): Promise<any> {
     response.type("application/json");
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -110,17 +110,23 @@ export class Installers {
   }
 
   @Get("/")
+  @Get("/version/:version")
   public async getInstallerVersions(
     @Res() response: Express.Response,
+    @PathParams("version") version: string,
   ): Promise<any> {
     response.type("application/json");
 
-    const kurlVersion = kurlVersionOrDefault();
+    let kurlVersion = version
+    if (version == undefined) {
+        kurlVersion = kurlVersionOrDefault();
+    }
 
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
     const resp = _.reduce(installerVersions, (accm, value, key) => {
       accm[key] = _.concat(["latest"], value);
+      accm[key] = [...new Set(accm[key])];
       return accm;
     }, {});
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -118,7 +118,7 @@ export class Installers {
     response.type("application/json");
 
     let kurlVersion = version;
-    if (version == undefined) {
+    if (!version) {
         kurlVersion = kurlVersionOrDefault();
     }
 

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -117,7 +117,7 @@ export class Installers {
   ): Promise<any> {
     response.type("application/json");
 
-    let kurlVersion = version
+    let kurlVersion = version;
     if (version == undefined) {
         kurlVersion = kurlVersionOrDefault();
     }


### PR DESCRIPTION
this commit changes the /installer endpoint to also support returning add-ons and external add-ons for past (older) releases.

a new parameter called "version" was added to the url, if it is not present the behavior remains the same but when present the endpoint returns add-ons and external add-ons supported by the provided version.

new url format:

/installer/version/:version

examples:
```
$ curl https://kurl.sh/installer
	returns the add-ons + external add-ons supported by the latest release

$ curl http://kurl.sh/installer/version/v2022.09.28-0
	returns the add-ons + external add-ons supported by the release v2022.09.28-0
```