### PR TITLE
Resolve Weave 2.6.x to correct patch version

### DIFF
--- a/src/installers/index.ts
+++ b/src/installers/index.ts
@@ -1529,7 +1529,7 @@ export class Installer {
     let next = versions;
     if (addon in Installer.replaceVersions) {
       Object.keys(Installer.replaceVersions[addon]).forEach((k: string) => {
-        next = versions.map(function(version: string): string {
+        next = next.map(function(version: string): string {
           return version === k ? Installer.replaceVersions[addon][k] : version;
         });
       });

--- a/src/test/installers/index.ts
+++ b/src/test/installers/index.ts
@@ -25,6 +25,31 @@ describe("Resolve version", () => {
     expect(version).to.equal("1.0.4");
   });
 
+  it("resolves correct weave 2.6 version without .x", async () => {
+    const version = await Installer.resolveVersion(installerVersions, "weave", "2.6.5");
+    expect(version).to.equal("2.6.5");
+  });
+
+  it("resolves correct weave 2.6 version with .x", async () => {
+    const version = await Installer.resolveVersion(installerVersions, "weave", "2.6.x");
+    expect(version).to.equal("2.6.5-20220825");
+  });
+
+  it("resolves correct weave 2.8 version without .x", async () => {
+    const version = await Installer.resolveVersion(installerVersions, "weave", "2.8.1");
+    expect(version).to.equal("2.8.1");
+  });
+
+  it("resolves correct weave 2.8 version with .x", async () => {
+    const version = await Installer.resolveVersion(installerVersions, "weave", "2.8.x");
+    expect(version).to.equal("2.8.1-20220825");
+  });
+
+  it("resolves weave latest", async () => {
+    const version = await Installer.resolveVersion(installerVersions, "weave", "latest");
+    expect(version).to.equal("2.6.5-20220825");
+  });
+
 });
 
 describe("greatest", () => {


### PR DESCRIPTION
2.6.x currently resolves to 2.6.5 rather than 2.6.5-[newest patch version]