### PR TITLE
bug: completely disable new linter

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -64,8 +64,8 @@ func main() {
 		log.Panic(err)
 	}
 	proxy := httputil.NewSingleHostReverseProxy(upstreamURL)
-	intercepter := &RequestIntercepter{proxy}
-	r.PathPrefix("/installer").Methods(http.MethodPost, http.MethodPut).Handler(intercepter)
+	// intercepter := &RequestIntercepter{proxy}
+	// r.PathPrefix("/installer").Methods(http.MethodPost, http.MethodPut).Handler(intercepter)
 	r.PathPrefix("/").Handler(proxy)
 
 	http.Handle("/", r)


### PR DESCRIPTION
due to a bug in our cloudflare worker all search params are being trimmed out. there is no way to determine if the user has or not requested for the new linter to be applied in this scenario.

this commit removes completely the request intercepter and bypasses everything to the backend directly.