### PR TITLE
Fix resolve latest and .x versions for pinned kurl installer version in the spec

### DIFF
--- a/src/client/index_test.ts
+++ b/src/client/index_test.ts
@@ -503,7 +503,7 @@ describe("PUT /installer/<id>", () => {
 
 describe("GET /<installerID>", () => {
   describe("/latest", async () => {
-    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions, {});
+    const latestResolve = Installer.latest(installerVersions).resolve(installerVersions, {});
 
     it(`injects k8s ${latestResolve.spec.kubernetes?.version}, weave ${latestResolve.spec.weave?.version}, rook ${latestResolve.spec.rook?.version}, contour ${latestResolve.spec.contour?.version}, registry ${latestResolve.spec.registry?.version}, prometheus ${latestResolve.spec.prometheus?.version}, docker ${latestResolve.spec.docker?.version}`, async () => {
       const script = await client.getInstallScript("latest");
@@ -561,7 +561,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(velero);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.velero?.version}`));
+      expect(script).to.match(new RegExp(`version: ${i.resolve(installerVersions, {}).spec.velero?.version}`));
     });
   });
 
@@ -577,7 +577,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(minio);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.minio?.version}`));
+      expect(script).to.match(new RegExp(`version: ${i.resolve(installerVersions, {}).spec.minio?.version}`));
     });
   });
 
@@ -593,7 +593,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(openebs);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.openebs?.version}`));
+      expect(script).to.match(new RegExp(`version: ${i.resolve(installerVersions, {}).spec.openebs?.version}`));
     });
   });
 
@@ -609,7 +609,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(ekco);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.ekco?.version}`));
+      expect(script).to.match(new RegExp(`version: ${i.resolve(installerVersions, {}).spec.ekco?.version}`));
     });
   });
 
@@ -625,7 +625,7 @@ describe("GET /<installerID>", () => {
       const i = Installer.parse(rookBlock);
       const script = await client.getInstallScript(id);
 
-      expect(script).to.match(new RegExp(`version: ${(await i.resolve(installerVersions, {})).spec.rook?.version}`));
+      expect(script).to.match(new RegExp(`version: ${i.resolve(installerVersions, {}).spec.rook?.version}`));
     });
   });
 
@@ -664,7 +664,7 @@ describe("GET /<installerID>", () => {
 
 describe("GET /<installerID>/join.sh", () => {
   describe("/latest/join.sh", async () => {
-    const latestResolve = await (Installer.latest(installerVersions)).resolve(installerVersions, {});
+    const latestResolve = Installer.latest(installerVersions).resolve(installerVersions, {});
 
     it(`injects k8s ${latestResolve.spec.kubernetes?.version}, weave ${latestResolve.spec.weave?.version}, rook ${latestResolve.spec.rook?.version}, contour ${latestResolve.spec.contour?.version}, registry ${latestResolve.spec.registry?.version}, prometheus ${latestResolve.spec.prometheus?.version}`, async () => {
       const script = await client.getJoinScript("latest");

--- a/src/controllers/Bundles.ts
+++ b/src/controllers/Bundles.ts
@@ -76,7 +76,7 @@ export class Bundle {
     }
 
     const externalVersions = getExternalAddonVersions();
-    installer = await installer.resolve(installerVersions, externalVersions);
+    installer = installer.resolve(installerVersions, externalVersions);
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
@@ -96,7 +96,7 @@ export class Bundle {
 
     const ret: BundleManifest = {layers: [], files: {}, images: []};
     const packageUrlPrefix = await getPackageUrlPrefix(this.distURL, kurlVersion);
-    ret.layers = (await installer.packages(installerVersions, kurlVersion)).map((pkg) => function (pkg: string) {
+    ret.layers = installer.packages(installerVersions, kurlVersion).map((pkg) => function (pkg: string) {
       if (pkg.startsWith("http")) { // if it starts with http, it's an s3override URL and should be used directly
         return pkg;
       }

--- a/src/controllers/InstallerAPI.ts
+++ b/src/controllers/InstallerAPI.ts
@@ -96,7 +96,7 @@ export class Installers {
     i.id = i.hash();
 
     const externalVersions = getExternalAddonVersions();
-    const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
+    const err = i.resolve(installerVersions, externalVersions).validate(installerVersions);
     if (err) {
       response.status(400);
       return err;
@@ -197,7 +197,7 @@ export class Installers {
     }
     if (resolve) {
       const externalVersions = getExternalAddonVersions();
-      installer = await installer.resolve(installerVersions, externalVersions);
+      installer = installer.resolve(installerVersions, externalVersions);
     }
     if (installer.id === "latest") {
       installer.id = "";
@@ -241,7 +241,7 @@ export class Installers {
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
     const externalVersions = getExternalAddonVersions();
-    const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
+    const err = i.resolve(installerVersions, externalVersions).validate(installerVersions);
     if (err) {
       response.status(400);
       return err;
@@ -301,7 +301,7 @@ export class Installers {
       const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
       const externalVersions = getExternalAddonVersions();
-      const err = await (await i.resolve(installerVersions, externalVersions)).validate(installerVersions);
+      const err = i.resolve(installerVersions, externalVersions).validate(installerVersions);
       if (err) {
         response.status(400);
         return err;

--- a/src/controllers/Scripts.ts
+++ b/src/controllers/Scripts.ts
@@ -61,9 +61,11 @@ export class Installers {
     }
 
     const externalVersions = getExternalAddonVersions();
-    installer = await installer.resolve(installerVersions, externalVersions);
+
+    // resolve the correct version if specified in the spec
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
+    installer = installer.resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -95,11 +97,11 @@ export class Installers {
     }
 
     const externalVersions = getExternalAddonVersions();
-    installer = await installer.resolve(installerVersions, externalVersions);
+
+    // resolve the correct version if specified in the spec
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
-
-    installer = await installer.resolve(installerVersions, externalVersions);
+    installer = installer.resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -125,9 +127,11 @@ export class Installers {
     }
 
     const externalVersions = getExternalAddonVersions();
-    installer = await installer.resolve(installerVersions, externalVersions);
+
+    // resolve the correct version if specified in the spec
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
+    installer = installer.resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -145,7 +149,7 @@ export class Installers {
     const installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
 
     const externalVersions = getExternalAddonVersions();
-    const installer = await (Installer.latest(installerVersions)).resolve(installerVersions, externalVersions);
+    const installer = Installer.latest(installerVersions).resolve(installerVersions, externalVersions);
 
     response.set("X-Kurl-Hash", installer.hash());
     response.status(200);
@@ -181,9 +185,11 @@ export class Installers {
     }
 
     const externalVersions = getExternalAddonVersions();
-    installer = await installer.resolve(installerVersions, externalVersions);
+
+    // resolve the correct version if specified in the spec
     kurlVersion = kurlVersionOrDefault(kvarg, installer);
     installerVersions = await getInstallerVersions(this.distURL, kurlVersion);
+    installer = installer.resolve(installerVersions, externalVersions);
 
     try {
       await this.metricsStore.saveSaasScriptEvent({

--- a/src/test/controllers/installers.ts
+++ b/src/test/controllers/installers.ts
@@ -750,7 +750,7 @@ spec:
         [
           typeMetaStableV1Beta1,
         ].forEach(async (yaml) => {
-          const out = await Installer.parse(yaml).validate(installerVersions);
+          const out = Installer.parse(yaml).validate(installerVersions);
 
           expect(out).to.equal(undefined);
         });
@@ -758,7 +758,7 @@ spec:
 
       describe("application slug exists", () => {
         it("=> void", async () => {
-          const out = await Installer.parse(kots).validate(installerVersions);
+          const out = Installer.parse(kots).validate(installerVersions);
 
           expect(out).to.equal(undefined);
         });
@@ -766,7 +766,7 @@ spec:
 
       describe("every option", () => {
         it("=> void", async () => {
-          const out = await Installer.parse(everyOption).validate(installerVersions);
+          const out = Installer.parse(everyOption).validate(installerVersions);
 
           expect(out).to.equal(undefined);
         });
@@ -774,7 +774,7 @@ spec:
 
       describe("unknown versions w/ overrides", () => {
         it("=> void", async () => {
-          const out = await Installer.parse(overrideUnknownVersion).validate(installerVersions);
+          const out = Installer.parse(overrideUnknownVersion).validate(installerVersions);
           expect(out).to.equal(undefined);
         });
       });
@@ -787,7 +787,7 @@ spec:
   kubernetes:
     version: ""
 `;
-        const noK8sOut = await Installer.parse(noK8s).validate(installerVersions);
+        const noK8sOut = Installer.parse(noK8s).validate(installerVersions);
         expect(noK8sOut).to.deep.equal({ error: { message: "Kubernetes version is required" } });
 
         const badK8s = `
@@ -795,7 +795,7 @@ spec:
   kubernetes:
     version: "0.15.3"
 `;
-        const badK8sOut = await Installer.parse(badK8s).validate(installerVersions);
+        const badK8sOut = Installer.parse(badK8s).validate(installerVersions);
         expect(badK8sOut).to.deep.equal({ error: { message: `Kubernetes version "0.15.3" is not supported` } });
       });
     });
@@ -809,7 +809,7 @@ spec:
   prometheus:
     version: 0.32.0
 `;
-        const out = await Installer.parse(yaml).validate(installerVersions);
+        const out = Installer.parse(yaml).validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: `Prometheus version "0.32.0" is not supported` } });
       });
@@ -817,7 +817,7 @@ spec:
 
     describe("kots version missing", () => {
       it("=> ErrorResponse", async () => {
-        const out = await Installer.parse(kotsNoVersion).validate(installerVersions);
+        const out = Installer.parse(kotsNoVersion).validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "spec/kotsadm must have required property 'version'" }});
       });
@@ -831,7 +831,7 @@ spec:
   docker:
     version: true`;
       const i = Installer.parse(yaml);
-      const out = await i.validate(installerVersions);
+      const out = i.validate(installerVersions);
 
       expect(out).to.deep.equal({ error: { message: "spec.docker.version should be string" } });
     });
@@ -845,7 +845,7 @@ spec:
     version: latest
     podCidrRange: abc`;
       const i = Installer.parse(yaml);
-      const out = await i.validate(installerVersions);
+      const out = i.validate(installerVersions);
 
       expect(out).to.deep.equal({ error: { message: "Weave podCidrRange \"abc\" is invalid" } });
     });
@@ -857,7 +857,7 @@ spec:
     version: latest
     serviceCidrRange: abc`;
       const i = Installer.parse(yaml);
-      const out = await i.validate(installerVersions);
+      const out = i.validate(installerVersions);
 
       expect(out).to.deep.equal({ error: { message: "Kubernetes serviceCidrRange \"abc\" is invalid" } });
     });
@@ -870,7 +870,7 @@ spec:
     version: latest
     seLinux: true`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "spec/kubernetes must NOT have additional properties" } });
       });
@@ -886,7 +886,7 @@ spec:
     version: 0.53.1-30.1.0
     serviceType: thisisatest`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Supported Prometheus service types are \"NodePort\" and \"ClusterIP\", not \"thisisatest\"" } });
       });
@@ -902,7 +902,7 @@ spec:
     version: 0.47.0-15.3.1
     serviceType: ClusterIP`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Prometheus service types are supported for version \"0.48.1-16.10.0\" and later, not \"0.47.0-15.3.1\"" } });
       });
@@ -918,7 +918,7 @@ spec:
     version: 0.48.1-16.10.0
     serviceType: ClusterIP`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal(undefined);
       });
@@ -933,7 +933,7 @@ spec:
   prometheus:
     version: 0.47.0-15.3.1`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Prometheus versions less than or equal to 0.49.0-17.1.3 are not compatible with Kubernetes 1.22+" } });
       });
@@ -948,7 +948,7 @@ spec:
   prometheus:
     version: 0.58.0-39.12.1`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Prometheus versions less than or equal to 0.59.0 are not compatible with Kubernetes 1.25+" } });
       });
@@ -963,7 +963,7 @@ spec:
   rook:
     version: 1.7.11`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Rook versions less than or equal to 1.9.10 are not compatible with Kubernetes 1.25+" } });
       });
@@ -978,7 +978,7 @@ spec:
   longhorn:
     version: 1.3.1`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Longhorn versions less than or equal to 1.4.0 are not compatible with Kubernetes 1.25+" } });
       });
@@ -996,7 +996,7 @@ spec:
     localPVStorageClassName: default
     isCstorEnabled: false`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal(undefined);
       });
@@ -1014,7 +1014,7 @@ spec:
     localPVStorageClassName: default
     isCstorEnabled: false`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Openebs version \"1.12.0\" is not compatible with Kubernetes versions 1.22+" } });
       });
@@ -1032,7 +1032,7 @@ spec:
     localPVStorageClassName: default
     isCstorEnabled: false`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal(undefined);
       });
@@ -1049,7 +1049,7 @@ spec:
     isCstorEnabled: true
     cstorStorageClassName: "abcd"`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Openebs version \"2.12.9\" does not support cstor in kURL" } });
       });
@@ -1064,7 +1064,7 @@ spec:
   docker:
     version: 20.10.5`;
         const i = Installer.parse(yaml);
-        const out = await i.validate(installerVersions);
+        const out = i.validate(installerVersions);
 
         expect(out).to.deep.equal({ error: { message: "Docker is not supported with Kubernetes versions 1.24+, please choose Containerd" } });
       });
@@ -1172,7 +1172,7 @@ spec:
 
   describe("latest", () => {
     it("should resolve all latest versions", async () => {
-      const i = await Installer.parse(allLatest).resolve(installerVersions, {});
+      const i = Installer.parse(allLatest).resolve(installerVersions, {});
 
       _.each(_.keys(i.spec), (config: string) => {
         if (i.spec[config].version) {
@@ -1184,7 +1184,7 @@ spec:
 
   describe("flannel", () => {
     it("should parse", async () => {
-      const i = await Installer.parse(everyOption).resolve(installerVersions, {});
+      const i = Installer.parse(everyOption).resolve(installerVersions, {});
 
       expect(i.spec.flannel).to.deep.equal({
         version: "0.20.0",
@@ -1196,7 +1196,7 @@ spec:
 
   describe("antrea", () => {
     it("should parse", async () => {
-      const i = await Installer.parse(everyOption).resolve(installerVersions, {});
+      const i = Installer.parse(everyOption).resolve(installerVersions, {});
 
       expect(i.spec.antrea).to.deep.equal({
         version: "1.4.0",
@@ -1261,7 +1261,7 @@ spec:
   describe("longhorn", () => {
     it("should parse", async () => {
       const i = Installer.parse(longhorn);
-      const pkgs = await i.packages(installerVersions, "");
+      const pkgs = i.packages(installerVersions, "");
 
       const hasHostLonghorn = _.some(pkgs, (pkg) => {
         return pkg === "host-longhorn";
@@ -1433,7 +1433,7 @@ spec:
     additionalImages:
     - postgres`;
       const i = Installer.parse(yaml);
-      const out = await i.validate(installerVersions);
+      const out = i.validate(installerVersions);
 
       expect(out).to.deep.equal({ error: { message: "spec/helm must have required property 'helmfileSpec'" } });
     });
@@ -1442,8 +1442,8 @@ spec:
   describe("packages", () => {
 
     it("should convert camel case to kebab case", async () => {
-      const i = await Installer.parse(everyOption).resolve(installerVersions, {});
-      const pkgs = await i.packages(installerVersions, "");
+      const i = Installer.parse(everyOption).resolve(installerVersions, {});
+      const pkgs = i.packages(installerVersions, "");
 
       const hasCertManager = _.some(pkgs, (pkg) => {
         return _.startsWith(pkg, "cert-manager");
@@ -1458,7 +1458,7 @@ spec:
 
     it("should include defaults", async () => {
       const i = Installer.parse(min);
-      const pkgs = await i.packages(installerVersions, "");
+      const pkgs = i.packages(installerVersions, "");
 
       const hasCommon = _.some(pkgs, (pkg) => {
         return pkg === "common";
@@ -1483,7 +1483,7 @@ spec:
 
     it("should include a versioned kurl-bin-utils", async () => {
       const i = Installer.parse(min);
-      const pkgs = await i.packages(installerVersions, "v2021.05.27-0");
+      const pkgs = i.packages(installerVersions, "v2021.05.27-0");
 
       const hasKurlBinUtils = _.some(pkgs, (pkg) => {
         return pkg === "kurl-bin-utils-v2021.05.27-0";
@@ -1493,7 +1493,7 @@ spec:
 
     it("should include kubernetes conformance images", async () => {
       const i = Installer.parse(conformance);
-      const pkgs = await i.packages(installerVersions, "");
+      const pkgs = i.packages(installerVersions, "");
 
       const hasSonobuoy = _.some(pkgs, (pkg) => {
         return pkg === "sonobuoy-0.50.0";
@@ -1513,7 +1513,7 @@ spec:
 
     it("should not include kubernetes conformance images for versions < 1.17", async () => {
       const i = Installer.parse(noConformance);
-      const pkgs = await i.packages(installerVersions, "");
+      const pkgs = i.packages(installerVersions, "");
 
       const hasSonobuoy = _.some(pkgs, (pkg) => {
         return pkg === "sonobuoy-0.50.0";
@@ -1533,7 +1533,7 @@ spec:
 
     it("should not include removed Kubernetes versions", async () => {
       const i = Installer.parse(noConformance);
-      const pkgs = await i.packages(installerVersions, "");
+      const pkgs = i.packages(installerVersions, "");
 
       const hasKubernetes16 = _.some(pkgs, (pkg) => {
         return pkg === "kubernetes-1.16.4";
@@ -1547,8 +1547,8 @@ spec:
     });
 
     it("should resolve external add-on package url", async () => {
-      const i = await Installer.parse(kotsExternal).resolve(installerVersions, {kotsadm: [{version: "1.84.0"}, {version: "1.85.0"}]});
-      const pkgs = await i.packages(installerVersions, "");
+      const i = Installer.parse(kotsExternal).resolve(installerVersions, {kotsadm: [{version: "1.84.0"}, {version: "1.85.0"}]});
+      const pkgs = i.packages(installerVersions, "");
 
       const kotsadm = _.find(pkgs, (pkg) => {
         return pkg.includes("/kotsadm-");

--- a/src/test/installers/index.ts
+++ b/src/test/installers/index.ts
@@ -6,47 +6,47 @@ import { installerVersions } from "../fixtures/installer-versions";
 describe("Resolve version", () => {
 
   it("resolves correct version without .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "rook", "1.0.4");
+    const version = Installer.resolveVersion(installerVersions, "rook", "1.0.4");
     expect(version).to.equal("1.0.4");
   });
 
   it("resolves correct version with .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "kubernetes", "1.18.x");
+    const version = Installer.resolveVersion(installerVersions, "kubernetes", "1.18.x");
     expect(version).to.equal("1.18.20");
   });
 
   it("resolves correct rook 1.0 version with .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "rook", "1.0.x");
+    const version = Installer.resolveVersion(installerVersions, "rook", "1.0.x");
     expect(version).to.equal("1.0.4-14.2.21");
   });
 
   it("resolves latest", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "rook", "latest");
+    const version = Installer.resolveVersion(installerVersions, "rook", "latest");
     expect(version).to.equal("1.0.4");
   });
 
   it("resolves correct weave 2.6 version without .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "weave", "2.6.5");
+    const version = Installer.resolveVersion(installerVersions, "weave", "2.6.5");
     expect(version).to.equal("2.6.5");
   });
 
   it("resolves correct weave 2.6 version with .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "weave", "2.6.x");
+    const version = Installer.resolveVersion(installerVersions, "weave", "2.6.x");
     expect(version).to.equal("2.6.5-20220825");
   });
 
   it("resolves correct weave 2.8 version without .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "weave", "2.8.1");
+    const version = Installer.resolveVersion(installerVersions, "weave", "2.8.1");
     expect(version).to.equal("2.8.1");
   });
 
   it("resolves correct weave 2.8 version with .x", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "weave", "2.8.x");
+    const version = Installer.resolveVersion(installerVersions, "weave", "2.8.x");
     expect(version).to.equal("2.8.1-20220825");
   });
 
   it("resolves weave latest", async () => {
-    const version = await Installer.resolveVersion(installerVersions, "weave", "latest");
+    const version = Installer.resolveVersion(installerVersions, "weave", "latest");
     expect(version).to.equal("2.6.5-20220825");
   });
 


### PR DESCRIPTION
## Description

When kurl.installerVersion is pinned in the spec, latest and .x versions do not resolve to the versions available in the specified kurl version.

## Reproduction Steps

```
$ curl https://k8s.kurl.sh/52933f4 | sudo bash
...
curl: (22) The requested URL returned error: 403
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (22) The requested URL returned error: 403 Forbidden
An error occurred on line 453
```
