### PR TITLE
Provider commit pipeline

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,6 +41,16 @@ jobs:
     - run: echo "::notice ::build test success"
 
   pact-provider-verify:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    uses: ./.github/workflows/pact-provider-verify.yaml
+    with:
+      PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: true
+    secrets:
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+
+  pact-provider-verify-fork:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/pact-provider-verify.yaml
     with:
       PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: false
@@ -57,6 +67,5 @@ jobs:
       PACT_RETRY_WHILE_UNKNOWN: '0'
       PACT_BROKER_CAN_I_DEPLOY_DRY_RUN: 'true'
     steps:
-      - uses: actions/checkout@v3
       - uses: replicatedhq/action-install-pact@main
       - run: make -C pact can-i-deploy

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -67,5 +67,6 @@ jobs:
       PACT_RETRY_WHILE_UNKNOWN: '0'
       PACT_BROKER_CAN_I_DEPLOY_DRY_RUN: 'true'
     steps:
+      - uses: actions/checkout@v3
       - uses: replicatedhq/action-install-pact@main
       - run: make -C pact can-i-deploy

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -57,5 +57,6 @@ jobs:
       PACT_RETRY_WHILE_UNKNOWN: '0'
       PACT_BROKER_CAN_I_DEPLOY_DRY_RUN: 'true'
     steps:
+      - uses: actions/checkout@v3
       - uses: replicatedhq/action-install-pact@main
       - run: make -C pact can-i-deploy

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -48,3 +48,14 @@ jobs:
       PACT_BROKER_BASE_URL: https://replicated.pactflow.io
       # read only token, safe
       PACT_BROKER_TOKEN: W2y60iAYJbPuWSL_wsObzw
+  
+  pact-can-i-deploy:
+    runs-on: ubuntu-latest
+    needs:
+      - pact-provider-verify
+    env:
+      PACT_RETRY_WHILE_UNKNOWN: '0'
+      PACT_BROKER_CAN_I_DEPLOY_DRY_RUN: 'true'
+    steps:
+      - uses: replicatedhq/action-install-pact@main
+      - run: make -C pact can-i-deploy

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -41,7 +41,7 @@ jobs:
     - run: echo "::notice ::build test success"
 
   pact-provider-verify:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ( github.event.pull_request.head.repo.full_name == github.repository ) && ( github.actor != 'dependabot[bot]' )
     uses: ./.github/workflows/pact-provider-verify.yaml
     with:
       PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: true
@@ -50,7 +50,7 @@ jobs:
       PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
 
   pact-provider-verify-fork:
-    if: github.event.pull_request.head.repo.full_name != github.repository
+    if: ( github.event.pull_request.head.repo.full_name != github.repository ) || ( github.actor == 'dependabot[bot]' )
     uses: ./.github/workflows/pact-provider-verify.yaml
     with:
       PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: false

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,6 +75,7 @@ jobs:
     env: 
       PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
       PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+      PACT_ENVIRONMENT: staging
     steps:
     - uses: actions/checkout@v3
 
@@ -105,8 +106,6 @@ jobs:
     - name: install Pact
       uses: replicatedhq/action-install-pact@main
     - name: can-i-deploy
-      env: 
-        PACT_ENVIRONMENT: staging
       run: make -C pact can-i-deploy
 
     - name: release
@@ -122,8 +121,6 @@ jobs:
           git push origin main
     
     - name: record deployment
-      env:
-        PACT_ENVIRONMENT: staging
       run: make -C pact record-deployment
 
   deploy-production-eks:
@@ -137,6 +134,7 @@ jobs:
     env: 
       PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
       PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+      PACT_ENVIRONMENT: production
     steps:
     - uses: actions/checkout@v3
     - name: kustomize
@@ -166,8 +164,6 @@ jobs:
     - name: install Pact
       uses: replicatedhq/action-install-pact@main
     - name: can-i-deploy
-      env: 
-        PACT_ENVIRONMENT: production
       run: make -C pact can-i-deploy
 
     - name: release
@@ -183,6 +179,4 @@ jobs:
           git push origin release
 
     - name: record deployment
-      env:
-        PACT_ENVIRONMENT: staging
       run: make -C pact record-deployment

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,6 +49,22 @@ jobs:
     - run: |
         docker push 799720048698.dkr.ecr.us-east-1.amazonaws.com/kurl:${GITHUB_SHA:0:7}
 
+  staging-pact-provider-verify:
+    uses: ./.github/workflows/pact-provider-verify.yaml
+    with:
+      PACT_CONSUMER_VERSION_SELECTOR: '{"deployedOrReleased":true,"environment":"staging"}'
+    secrets:
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+
+  production-pact-provider-verify:
+    uses: ./.github/workflows/pact-provider-verify.yaml
+    with:
+      PACT_CONSUMER_VERSION_SELECTOR: '{"deployedOrReleased":true,"environment":"production"}'
+    secrets:
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+  
   deploy-staging-eks:
     environment: 
       name: staging
@@ -56,6 +72,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
     - staging-docker-image
+    - staging-pact-provider-verify
     steps:
     - uses: actions/checkout@v3
 
@@ -83,6 +100,13 @@ jobs:
         echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' \
           >> ~/.ssh/known_hosts
 
+    - name: install Pact
+      uses: replicatedhq/action-install-pact@main
+    - name: can-i-deploy
+      env: 
+        PACT_ENVIRONMENT: staging
+      run: make -C pact can-i-deploy
+
     - name: release
       run: |
         cd ~ && git clone --single-branch -b main git@github.com:replicatedcom/gitops-deploy
@@ -102,6 +126,7 @@ jobs:
     runs-on: ubuntu-20.04
     needs:
     - production-docker-image
+    - production-pact-provider-verify
     steps:
     - uses: actions/checkout@v3
     - name: kustomize
@@ -127,6 +152,13 @@ jobs:
         chmod 400 ~/.ssh/id_rsa
         echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' \
           >> ~/.ssh/known_hosts
+
+    - name: install Pact
+      uses: replicatedhq/action-install-pact@main
+    - name: can-i-deploy
+      env: 
+        PACT_ENVIRONMENT: production
+      run: make -C pact can-i-deploy
 
     - name: release
       run: |

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,7 +6,6 @@ on:
     - main
 
 jobs:
-
   staging-docker-image:
     runs-on: ubuntu-20.04
     steps:
@@ -73,6 +72,9 @@ jobs:
     needs:
     - staging-docker-image
     - staging-pact-provider-verify
+    env: 
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
     steps:
     - uses: actions/checkout@v3
 
@@ -118,6 +120,11 @@ jobs:
         git add .
         git commit --allow-empty -m "https://github.com/replicatedhq/kurl-api/actions/runs/${GITHUB_RUN_ID}" && \
           git push origin main
+    
+    - name: record deployment
+      env:
+        PACT_ENVIRONMENT: staging
+      run: make -C pact record-deployment
 
   deploy-production-eks:
     environment: 
@@ -127,6 +134,9 @@ jobs:
     needs:
     - production-docker-image
     - production-pact-provider-verify
+    env: 
+      PACT_BROKER_BASE_URL: ${{ secrets.PACT_BROKER_BASE_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: kustomize
@@ -171,3 +181,8 @@ jobs:
         git add .
         git commit --allow-empty -m "https://github.com/replicatedhq/kurl-api/actions/runs/${GITHUB_RUN_ID}" && \
           git push origin release
+
+    - name: record deployment
+      env:
+        PACT_ENVIRONMENT: staging
+      run: make -C pact record-deployment

--- a/.github/workflows/pact-provider-verify.yaml
+++ b/.github/workflows/pact-provider-verify.yaml
@@ -33,7 +33,7 @@ env:
   PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
   PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: ${{ github.event.client_payload && 'true' || inputs.PACT_BROKER_PUBLISH_VERIFICATION_RESULTS }}
   PACT_URL: ${{ github.event.client_payload.pact_url }}
-  GIT_COMMIT: ${{ github.event.client_payload.sha || env.GITHUB_SHA }}
+  GIT_COMMIT: ${{ github.event.client_payload.sha || github.sha }}
   GIT_BRANCH: ${{ github.event.client_payload.branch }}
   DESCRIPTION: ${{ github.event.client_payload.message }}
 

--- a/.github/workflows/pact-provider-verify.yaml
+++ b/.github/workflows/pact-provider-verify.yaml
@@ -33,7 +33,7 @@ env:
   PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
   PACT_BROKER_PUBLISH_VERIFICATION_RESULTS: ${{ github.event.client_payload && 'true' || inputs.PACT_BROKER_PUBLISH_VERIFICATION_RESULTS }}
   PACT_URL: ${{ github.event.client_payload.pact_url }}
-  GIT_COMMIT: ${{ github.event.client_payload.sha }}
+  GIT_COMMIT: ${{ github.event.client_payload.sha || env.GITHUB_SHA }}
   GIT_BRANCH: ${{ github.event.client_payload.branch }}
   DESCRIPTION: ${{ github.event.client_payload.message }}
 

--- a/pact/Makefile
+++ b/pact/Makefile
@@ -37,3 +37,10 @@ can-i-deploy:
 	--to-environment $${PACT_ENVIRONMENT:-staging} \
 	--retry-while-unknown $${PACT_RETRY_WHILE_UNKNOWN:-30} \
 	--retry-interval $${PACT_RETRY_INTERVAL:-10}
+
+.PHONY: record-deployment
+record-deployment:
+	pact-broker record-deployment \
+	--pacticipant kurl-api \
+	--version ${GITHUB_SHA} \
+	--environment $${PACT_ENVIRONMENT:-staging}

--- a/pact/Makefile
+++ b/pact/Makefile
@@ -1,10 +1,12 @@
-PACT_BROKER_PUBLISH_VERIFICATION_RESULTS ?= false
 PACT_BROKER_BASE_URL ?= https://replicated.pactflow.io
 PACT_BROKER_TOKEN ?= W2y60iAYJbPuWSL_wsObzw # read-only token, safe
+PACT_BROKER_PUBLISH_VERIFICATION_RESULTS ?= false
+PACT_BROKER_CAN_I_DEPLOY_DRY_RUN ?= false
 
 export PACT_BROKER_BASE_URL
-export PACT_BROKER_PUBLISH_VERIFICATION_RESULTS
 export PACT_BROKER_TOKEN
+export PACT_BROKER_PUBLISH_VERIFICATION_RESULTS
+export PACT_BROKER_CAN_I_DEPLOY_DRY_RUN
 
 .PHONY: provider-verify
 provider-verify: verify-setup verify verify-teardown
@@ -21,9 +23,17 @@ verify:
 		--provider-base-url="http://localhost:3000" \
 		--provider=kurl-api \
 		--provider-app-version=${GIT_COMMIT} \
-		$$([ -n "${PACT_URL}" ] || echo "--consumer-version-selector="$${PACT_CONSUMER_VERSION_SELECTOR:-'{"deployedOrReleased":true,"environment":"staging"}'}) \
-		$$([ "${PACT_BROKER_PUBLISH_VERIFICATION_RESULTS}" = "true" ] && echo "--publish-verification-results" ) 
+		$$([ -n "${PACT_URL}" ] || echo "--consumer-version-selector="$${PACT_CONSUMER_VERSION_SELECTOR:-'{"deployedOrReleased":true,"environment":"staging"}'}) 
 
 .PHONY: verify-teardown
 verify-teardown:
 	docker compose down --remove-orphans
+
+.PHONY: can-i-deploy
+can-i-deploy:
+	pact-broker can-i-deploy \
+	--pacticipant kurl-api \
+	--version ${GITHUB_SHA} \
+	--to-environment $${PACT_ENVIRONMENT:-staging} \
+	--retry-while-unknown $${PACT_RETRY_WHILE_UNKNOWN:-30} \
+	--retry-interval $${PACT_RETRY_INTERVAL:-10}


### PR DESCRIPTION
* Add provider commit pipeline including blocking can-i-deploy checks and deployment recording
* Re-add publish for non-forked pulls to enable can-i-deploy dry check. If demand warrants we can put an ok-to-test flow on this